### PR TITLE
Get status config from "@primer/deploy" key in package.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM node:10-slim
 
-LABEL version="0.0.0"
-LABEL repository="http://github.com/primer/actions"
-LABEL homepage="http://github.com/primer/actions/tree/master/deploy"
-LABEL maintainer="GitHub Design Systems <design-systems@github.com>"
-
 LABEL com.github.actions.name="Primer deploy"
 LABEL com.github.actions.description="Deploy to now with branch and tag aliases"
 LABEL com.github.actions.icon="triangle"
 LABEL com.github.actions.color="black"
+
+LABEL version="2.0.1"
+LABEL repository="http://github.com/primer/actions"
+LABEL homepage="http://github.com/primer/actions/tree/master/deploy"
+LABEL maintainer="GitHub Design Systems <design-systems@github.com>"
 
 COPY . /
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ LABEL repository="http://github.com/primer/actions"
 LABEL homepage="http://github.com/primer/actions/tree/master/deploy"
 LABEL maintainer="GitHub Design Systems <design-systems@github.com>"
 
-COPY . /
-WORKDIR /
+WORKDIR /primer-deploy
+COPY . .
 RUN ["npm", "install", "--production"]
 
-ENTRYPOINT ["/entrypoint.js"]
+ENTRYPOINT ["/primer-deploy/entrypoint.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL com.github.actions.description="Deploy to now with branch and tag aliases"
 LABEL com.github.actions.icon="triangle"
 LABEL com.github.actions.color="black"
 
-LABEL version="2.0.1"
+LABEL version="2.0.0"
 LABEL repository="http://github.com/primer/actions"
 LABEL homepage="http://github.com/primer/actions/tree/master/deploy"
 LABEL maintainer="GitHub Design Systems <design-systems@github.com>"

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -18,12 +18,12 @@ const yargs = require('yargs')
 const {argv} = yargs
 
 if (argv.help) {
-  return yargs.showHelp()
+  yargs.showHelp()
+  process.exit(0)
 }
 
 const {promisify} = require('util')
 const writeFile = promisify(require('fs').writeFile)
-const {dirname, join} = require('path')
 const deploy = require('.')
 
 deploy(argv, argv._)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2665,6 +2665,15 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "github-action-meta": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/github-action-meta/-/github-action-meta-0.1.2.tgz",
+      "integrity": "sha512-zyMbea3LYQ/oOlyn/JyD7Dqg6Sw+d9y3aEn9AZw3COoxANe6htolvjbDopUIRFY08idaE2jCgDj5wM/xvOe7qQ==",
+      "requires": {
+        "interpolate": "^0.1.0",
+        "yargs": "^12.0.5"
+      }
+    },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -2946,6 +2955,11 @@
         "strip-ansi": "^5.0.0",
         "through": "^2.3.6"
       }
+    },
+    "interpolate": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/interpolate/-/interpolate-0.1.0.tgz",
+      "integrity": "sha1-tgF3pLqUH7NyTIIZBdmareE9Hfk="
     },
     "invariant": {
       "version": "2.2.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "primer-deploy": "entrypoint.js"
   },
   "scripts": {
-    "lint": "eslint src",
+    "lint": "eslint *.js src",
     "test": "jest"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "action-status": "^0.1.1",
     "execa": "^1.0.0",
+    "github-action-meta": "^0.1.2",
     "now": "^13.1.2",
     "yargs": "^12.0.5"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@primer/deploy",
+  "version": "2.0.0",
   "author": "GitHub, Inc.",
   "license": "MIT",
   "bin": {
@@ -26,6 +27,5 @@
     "eslint-plugin-github": "^1.8.1",
     "jest": "^24.0.0",
     "mocked-env": "^1.2.4"
-  },
-  "version": "2.0.0"
+  }
 }

--- a/src/__tests__/deploy.js
+++ b/src/__tests__/deploy.js
@@ -183,7 +183,7 @@ describe('deploy()', () => {
     mockResolve(now, 'derp-123.now.sh')
     mockEnv({GITHUB_REF: 'refs/heads/derp'})
 
-    return deploy().then(res => {
+    return deploy().then(() => {
       expect(aliasStatus).toHaveBeenCalledWith('hi-derp.now.sh', statusOptions)
     })
   })

--- a/src/__tests__/deploy.js
+++ b/src/__tests__/deploy.js
@@ -8,15 +8,15 @@ jest.mock('../now')
 jest.mock('../read-json')
 jest.mock('../alias-status')
 
+now.mockImplementation(() => Promise.resolve('<mocked url>'))
 aliasStatus.mockImplementation(() => Promise.resolve({}))
 
 describe('deploy()', () => {
   let restoreEnv = () => {}
   afterEach(() => {
     restoreEnv()
-    // clear the call data
+    aliasStatus.mockReset()
     now.mockReset()
-    // restore the original behavior
     readJSON.mockReset()
   })
 
@@ -28,7 +28,7 @@ describe('deploy()', () => {
     })
 
     const root = 'foo-123.now.sh'
-    now.mockImplementation(() => Promise.resolve(root))
+    mockResolve(now, root)
     mockEnv({GITHUB_REF: ''})
 
     return deploy().then(res => {
@@ -47,7 +47,7 @@ describe('deploy()', () => {
 
     const root = 'foo-123.now.sh'
     const alias = 'foo-bar.now.sh'
-    now.mockImplementation(() => Promise.resolve(root))
+    mockResolve(now, root)
     mockEnv({GITHUB_REF: 'refs/heads/bar'})
 
     return deploy().then(res => {
@@ -68,7 +68,7 @@ describe('deploy()', () => {
     })
 
     const root = 'hello-123.now.sh'
-    now.mockImplementation(() => Promise.resolve(root))
+    mockResolve(now, root)
     mockEnv({GITHUB_REF: 'refs/heads/master'})
 
     return deploy().then(res => {
@@ -90,7 +90,7 @@ describe('deploy()', () => {
 
     const root = 'foo-123.now.sh'
     const alias = 'foo-bar.now.sh'
-    now.mockImplementation(() => Promise.resolve(root))
+    mockResolve(now, root)
     mockEnv({GITHUB_REF: 'refs/heads/bar'})
 
     return deploy().then(res => {
@@ -112,7 +112,7 @@ describe('deploy()', () => {
 
     const root = 'primer-style-123.now.sh'
     const alias = 'primer-style.now.sh'
-    now.mockImplementation(() => Promise.resolve(root))
+    mockResolve(now, root)
     mockEnv({GITHUB_REF: 'refs/heads/master'})
 
     return deploy().then(res => {
@@ -131,9 +131,9 @@ describe('deploy()', () => {
       'rules.json': null
     })
 
-    const root = 'primer-css-v12.now.sh'
+    const root = 'primer-css-abc123.now.sh'
     const alias = 'primer-css-v12.now.sh'
-    now.mockImplementation(() => Promise.resolve(root))
+    mockResolve(now, root)
     mockEnv({GITHUB_REF: 'refs/heads/v12'})
 
     return deploy({}, ['docs']).then(res => {
@@ -141,6 +141,50 @@ describe('deploy()', () => {
       expect(now).toHaveBeenNthCalledWith(1, ['docs'])
       expect(now).toHaveBeenNthCalledWith(2, ['docs', 'alias', root, alias])
       expect(res).toEqual({name: '@primer/css', root, alias, url: alias})
+    })
+  })
+
+  it('respects the @primer/config "releaseBranch" key in package.json', () => {
+    const alias = 'derp.style'
+    mockFiles({
+      'package.json': {
+        name: 'derp',
+        '@primer/deploy': {
+          releaseBranch: 'release'
+        }
+      },
+      'now.json': {alias},
+      'rules.json': null
+    })
+
+    const root = 'derp-abc123.now.sh'
+    mockResolve(now, root)
+    mockEnv({GITHUB_REF: 'refs/heads/release'})
+
+    return deploy().then(res => {
+      expect(now).toHaveBeenCalledTimes(2)
+      expect(now).toHaveBeenNthCalledWith(1, [])
+      expect(now).toHaveBeenNthCalledWith(2, ['alias', root, alias])
+      expect(res).toEqual({name: 'derp', root, url: alias})
+    })
+  })
+
+  it('passes the "status" key to aliasStatus() calls', () => {
+    const statusOptions = {context: 'hello'}
+    mockFiles({
+      'package.json': {
+        name: 'hi',
+        '@primer/deploy': {
+          status: statusOptions
+        }
+      }
+    })
+
+    mockResolve(now, 'derp-123.now.sh')
+    mockEnv({GITHUB_REF: 'refs/heads/derp'})
+
+    return deploy().then(res => {
+      expect(aliasStatus).toHaveBeenCalledWith('hi-derp.now.sh', statusOptions)
     })
   })
 
@@ -154,5 +198,9 @@ describe('deploy()', () => {
         return files[path]
       }
     })
+  }
+
+  function mockResolve(fn, value) {
+    fn.mockImplementation(() => Promise.resolve(value))
   }
 })

--- a/src/get-branch.js
+++ b/src/get-branch.js
@@ -1,4 +1,2 @@
-module.exports = function getBranch() {
-  const {GITHUB_REF = ''} = process.env
-  return GITHUB_REF.replace('refs/heads/', '')
-}
+const meta = require('github-action-meta')
+module.exports = () => meta.git.branch || ''


### PR DESCRIPTION
We have a need in primer/css to customize the name ("context") of the status checks that this action creates (from `deploy/alias` to `docs`). I've confirmed that this works in https://github.com/primer/primer/pull/666/commits/5272cd30fe01d2f20479ee228f865d5af7390211 (see [package.json](https://github.com/primer/primer/blob/5272cd30fe01d2f20479ee228f865d5af7390211/package.json#L43-L47)):

![image](https://user-images.githubusercontent.com/113896/52372931-3e05ff80-2a0e-11e9-8f27-dc104ceb8e47.png)