### PR TITLE
Release 3.0.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,11 @@ module.exports = {
   extends: [
     'plugin:github/es6'
   ],
+  parserOptions: {
+    ecmaVersion: 2018
+  },
   rules: {
-    'no-console': 0
+    'no-console': 0,
+    'prefer-promise-reject-errors': 0
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL com.github.actions.description="Deploy to now with branch and tag aliases"
 LABEL com.github.actions.icon="triangle"
 LABEL com.github.actions.color="black"
 
-LABEL version="2.2.0"
+LABEL version="3.0.0"
 LABEL repository="http://github.com/primer/actions"
 LABEL homepage="http://github.com/primer/actions/tree/master/deploy"
 LABEL maintainer="GitHub Design Systems <design-systems@github.com>"

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -16,6 +16,10 @@ const yargs = require('yargs')
     default: 3,
     describe: 'Re-try deployment this number of times before giving up'
   })
+  .option('verify', {
+    type: 'boolean',
+    describe: 'Unless provided, pass --no-verify to the Now CLI'
+  })
   .option('help', {
     alias: 'h',
     type: 'boolean',

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+const deploy = require('.')
+const {DEFAULT_RETRIES} = deploy
 const yargs = require('yargs')
   .option('out', {
     alias: 'o',
@@ -13,7 +15,7 @@ const yargs = require('yargs')
   .option('retries', {
     alias: 'r',
     type: 'number',
-    default: 3,
+    default: DEFAULT_RETRIES,
     describe: 'Re-try deployment this number of times before giving up'
   })
   .option('verify', {
@@ -34,7 +36,6 @@ if (argv.help) {
 
 const {promisify} = require('util')
 const writeFile = promisify(require('fs').writeFile)
-const deploy = require('.')
 
 deploy(argv, argv._)
   .then(res => {

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -10,6 +10,12 @@ const yargs = require('yargs')
     type: 'boolean',
     describe: `Print the sequence of commands, but don't actually run anything`
   })
+  .option('retries', {
+    alias: 'r',
+    type: 'number',
+    default: 3,
+    describe: 'Re-try deployment this number of times before giving up'
+  })
   .option('help', {
     alias: 'h',
     type: 'boolean',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/deploy",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/deploy",
-  "version": "2.2.2",
+  "version": "3.0.0",
   "author": "GitHub, Inc.",
   "license": "MIT",
   "bin": {

--- a/src/__tests__/deploy.js
+++ b/src/__tests__/deploy.js
@@ -39,7 +39,7 @@ describe('deploy()', () => {
 
     return deploy().then(res => {
       expect(now).toHaveBeenCalledTimes(1)
-      expect(now).toHaveBeenCalledWith([])
+      expect(now).toHaveBeenCalledWith(['--no-verify'])
       expect(res).toEqual({name: 'foo', root, url: root})
     })
   })
@@ -58,7 +58,7 @@ describe('deploy()', () => {
 
     return deploy().then(res => {
       expect(now).toHaveBeenCalledTimes(2)
-      expect(now).toHaveBeenNthCalledWith(1, [])
+      expect(now).toHaveBeenNthCalledWith(1, ['--no-verify'])
       expect(now).toHaveBeenNthCalledWith(2, ['alias', root, alias])
       expect(res).toEqual({name: 'foo', root, alias, url: alias})
     })
@@ -79,7 +79,7 @@ describe('deploy()', () => {
 
     return deploy().then(res => {
       expect(now).toHaveBeenCalledTimes(2)
-      expect(now).toHaveBeenNthCalledWith(1, [])
+      expect(now).toHaveBeenNthCalledWith(1, ['--no-verify'])
       expect(now).toHaveBeenNthCalledWith(2, ['alias', root, alias])
       expect(res).toEqual({name, root, url: alias})
     })
@@ -101,7 +101,7 @@ describe('deploy()', () => {
 
     return deploy().then(res => {
       expect(now).toHaveBeenCalledTimes(2)
-      expect(now).toHaveBeenNthCalledWith(1, [])
+      expect(now).toHaveBeenNthCalledWith(1, ['--no-verify'])
       expect(now).toHaveBeenNthCalledWith(2, ['alias', root, alias])
       expect(res).toEqual({name: 'foo', root, alias, url: alias})
     })
@@ -123,7 +123,7 @@ describe('deploy()', () => {
 
     return deploy().then(res => {
       expect(now).toHaveBeenCalledTimes(3)
-      expect(now).toHaveBeenNthCalledWith(1, [])
+      expect(now).toHaveBeenNthCalledWith(1, ['--no-verify'])
       expect(now).toHaveBeenNthCalledWith(2, ['alias', root, alias])
       expect(now).toHaveBeenNthCalledWith(3, ['alias', '-r', 'rules.json', prodAlias])
       expect(res).toEqual({name: 'primer-style', root, alias, url: prodAlias})
@@ -144,7 +144,7 @@ describe('deploy()', () => {
 
     return deploy({}, ['docs']).then(res => {
       expect(now).toHaveBeenCalledTimes(2)
-      expect(now).toHaveBeenNthCalledWith(1, ['docs'])
+      expect(now).toHaveBeenNthCalledWith(1, ['--no-verify', 'docs'])
       expect(now).toHaveBeenNthCalledWith(2, ['docs', 'alias', root, alias])
       expect(res).toEqual({name: '@primer/css', root, alias, url: alias})
     })
@@ -169,7 +169,7 @@ describe('deploy()', () => {
 
     return deploy().then(res => {
       expect(now).toHaveBeenCalledTimes(2)
-      expect(now).toHaveBeenNthCalledWith(1, [])
+      expect(now).toHaveBeenNthCalledWith(1, ['--no-verify'])
       expect(now).toHaveBeenNthCalledWith(2, ['alias', root, alias])
       expect(res).toEqual({name: 'derp', root, url: alias})
     })
@@ -208,13 +208,13 @@ describe('deploy()', () => {
     })
 
     it('rejects after the third try', async () => {
-      const message ='simulated failure'
+      const message = 'simulated failure'
       now.mockImplementation(() => Promise.reject(message))
       await expect(deploy()).rejects.toBe(message)
       expect(now).toHaveBeenCalledTimes(3)
     })
 
-    it('respects the "retries" option', async () => {
+    it('respects the "retries" option', () => {
       const url = 'https://five-times.now.sh'
       now
         .mockImplementationOnce(() => Promise.reject('simulated failure 1'))
@@ -226,6 +226,13 @@ describe('deploy()', () => {
         expect(res.url).toBe(url)
         expect(now).toHaveBeenCalledTimes(5)
       })
+    })
+  })
+
+  it('respects the "verify" option', () => {
+    return deploy({verify: true}).then(res => {
+      expect(now).toHaveBeenCalledTimes(1)
+      expect(now).toHaveBeenNthCalledWith(1, [])
     })
   })
 

--- a/src/__tests__/deploy.js
+++ b/src/__tests__/deploy.js
@@ -22,8 +22,9 @@ describe('deploy()', () => {
   afterEach(() => {
     restoreEnv()
     aliasStatus.mockReset()
-    now.mockReset()
     readJSON.mockReset()
+    // restore brings back the original implementation!
+    now.mockRestore()
   })
 
   it('calls now() once when GITHUB_REF is unset', () => {

--- a/src/__tests__/deploy.js
+++ b/src/__tests__/deploy.js
@@ -229,8 +229,8 @@ describe('deploy()', () => {
     })
   })
 
-  it('respects the "verify" option', () => {
-    return deploy({verify: true}).then(res => {
+  it('does *not* call `now --no-verify` when the "verify" option is truthy', () => {
+    return deploy({verify: true}).then(() => {
       expect(now).toHaveBeenCalledTimes(1)
       expect(now).toHaveBeenNthCalledWith(1, [])
     })

--- a/src/__tests__/now.js
+++ b/src/__tests__/now.js
@@ -2,6 +2,8 @@ const execa = require('execa')
 const mockedEnv = require('mocked-env')
 const now = require('../now')
 
+const {NOW_BIN} = now
+
 jest.mock('execa')
 execa.mockImplementation(() => Promise.resolve({stderr: '', stdout: ''}))
 
@@ -17,13 +19,13 @@ describe('now()', () => {
   it('calls `npx now --token=$NOW_TOKEN` with no additional args', () => {
     mockEnv({NOW_TOKEN: 'xyz'})
     now()
-    expect(execa).lastCalledWith('npx', ['now', '--token=xyz'], {stderr: 'inherit'})
+    expect(execa).lastCalledWith(NOW_BIN, ['--token=xyz'], {stderr: 'inherit'})
   })
 
   it('calls with additional arguments passed as an array', () => {
     mockEnv({NOW_TOKEN: 'abc'})
     now(['foo', 'bar'])
-    expect(execa).lastCalledWith('npx', ['now', '--token=abc', 'foo', 'bar'], {stderr: 'inherit'})
+    expect(execa).lastCalledWith(NOW_BIN, ['--token=abc', 'foo', 'bar'], {stderr: 'inherit'})
   })
 
   function mockEnv(env) {

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -6,6 +6,7 @@ const readJSON = require('./read-json')
 const retry = require('./retry')
 
 const CONFIG_KEY = '@primer/deploy'
+const DEFAULT_RETRIES = 3
 
 module.exports = function deploy(options = {}, nowArgs = []) {
   const {dryRun} = options
@@ -19,7 +20,7 @@ module.exports = function deploy(options = {}, nowArgs = []) {
   const {releaseBranch = 'master'} = config
 
   const configAndOptions = Object.assign({}, config, options)
-  const {verify = false, retries = 0} = configAndOptions
+  const {verify = false, retries = DEFAULT_RETRIES} = configAndOptions
 
   const name = nowJson.name || packageJson.name || dirname(process.cwd())
   const branch = getBranch(name)
@@ -75,6 +76,8 @@ module.exports = function deploy(options = {}, nowArgs = []) {
       }
     })
 }
+
+Object.assign(module.exports, {DEFAULT_RETRIES})
 
 function log(message, ...args) {
   console.warn(`[deploy] ${message}`, ...args)

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -19,7 +19,7 @@ module.exports = function deploy(options = {}, nowArgs = []) {
   const {releaseBranch = 'master'} = config
 
   const configAndOptions = Object.assign({}, config, options)
-  const {verify = false, retries = 3} = configAndOptions
+  const {verify = false, retries = 0} = configAndOptions
 
   const name = nowJson.name || packageJson.name || dirname(process.cwd())
   const branch = getBranch(name)

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -19,13 +19,14 @@ module.exports = function deploy(options = {}, nowArgs = []) {
   const {releaseBranch = 'master'} = config
 
   const configAndOptions = Object.assign({}, config, options)
-  const retries = configAndOptions.retries || 3
+  const {verify, retries = 3} = configAndOptions
 
   const name = nowJson.name || packageJson.name || dirname(process.cwd())
   const branch = getBranch(name)
 
   log(`deploying "${name}" with now...`)
-  return retry(() => now(nowArgs), retries)
+  const deployArgs = verify ? nowArgs : ['--no-verify', ...nowArgs]
+  return retry(() => now(deployArgs), retries)
     .then(url => {
       if (url) {
         log(`root deployment: ${url}`)

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -19,7 +19,7 @@ module.exports = function deploy(options = {}, nowArgs = []) {
   const {releaseBranch = 'master'} = config
 
   const configAndOptions = Object.assign({}, config, options)
-  const {verify, retries = 3} = configAndOptions
+  const {verify = false, retries = 3} = configAndOptions
 
   const name = nowJson.name || packageJson.name || dirname(process.cwd())
   const branch = getBranch(name)

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -3,6 +3,7 @@ const getBranch = require('./get-branch')
 const aliasStatus = require('./alias-status')
 const getBranchAlias = require('./get-alias')
 const readJSON = require('./read-json')
+const retry = require('./retry')
 
 const CONFIG_KEY = '@primer/deploy'
 
@@ -17,11 +18,14 @@ module.exports = function deploy(options = {}, nowArgs = []) {
   const config = packageJson[CONFIG_KEY] || {}
   const {releaseBranch = 'master'} = config
 
+  const configAndOptions = Object.assign({}, config, options)
+  const retries = configAndOptions.retries || 3
+
   const name = nowJson.name || packageJson.name || dirname(process.cwd())
   const branch = getBranch(name)
 
   log(`deploying "${name}" with now...`)
-  return now(nowArgs)
+  return retry(() => now(nowArgs), retries)
     .then(url => {
       if (url) {
         log(`root deployment: ${url}`)

--- a/src/now.js
+++ b/src/now.js
@@ -1,6 +1,8 @@
 const execa = require('execa')
 
-const {bin: {now: NOW_BIN_PATH}} = require('now/package.json')
+const {
+  bin: {now: NOW_BIN_PATH}
+} = require('now/package.json')
 const NOW_BIN = require.resolve(`now/${NOW_BIN_PATH}`)
 
 module.exports = function now(args = []) {

--- a/src/now.js
+++ b/src/now.js
@@ -1,10 +1,15 @@
 const execa = require('execa')
 
+const {bin: {now: NOW_BIN_PATH}} = require('now/package.json')
+const NOW_BIN = require.resolve(`now/${NOW_BIN_PATH}`)
+
 module.exports = function now(args = []) {
   const {NOW_TOKEN} = process.env
   if (!NOW_TOKEN) {
     throw new Error(`The NOW_TOKEN env var is required`)
   }
-  const nowArgs = ['now', `--token=${NOW_TOKEN}`, ...args]
-  return execa('npx', nowArgs, {stderr: 'inherit'}).then(res => res.stdout)
+  const nowArgs = [`--token=${NOW_TOKEN}`, ...args]
+  return execa(NOW_BIN, nowArgs, {stderr: 'inherit'}).then(res => res.stdout)
 }
+
+Object.assign(module.exports, {NOW_BIN})

--- a/src/retry.js
+++ b/src/retry.js
@@ -1,0 +1,21 @@
+module.exports = function retry(fn, times) {
+  if (times < 0 || !isFinite(times)) {
+    throw new Error(`retry() expects a positive number of times; got: ${times}`)
+  }
+  let count = 0
+  return next()
+
+  function next() {
+    // console.warn(`[retry ${count}]`)
+    return fn().catch(error => {
+      if (++count < times) {
+        // console.warn(`[retry ${count} failed; trying again]`)
+        return next()
+      } else {
+        // console.warn(`[retry failed ${count} times]`)
+        throw error
+      }
+    })
+  }
+}
+

--- a/src/retry.js
+++ b/src/retry.js
@@ -18,4 +18,3 @@ module.exports = function retry(fn, times) {
     })
   }
 }
-


### PR DESCRIPTION
### :boom: Breaking changes
* We now run the `now` CLI that's installed in this package. Repos using this action should be able to `npm uninstall --save now` and speed up installations a bit. Fixes #10.

* We now pass `--no-verify` to the `now` CLI by default, which should speed up deployments, especially ones that scale. If verification is important, you can either:
    1. Pass the `--verify` argument via `args = ["--verify"]` in your Actions workflow; or
    2. Add `{"@primer/deploy":{"verify":true}}` to your `package.json`.

    Fixes #9.

### :bug: Bug fixes
* We now retry the initial ("root") deployment 3 times by default to work around some increasingly frequent and cryptic errors with no useful output. My hunch is that these were just intermittent failures that we can push through, which seems to have proven true (anecdotally at least) in https://github.com/primer/components/pull/429.

    To adjust the number of retries, pass `--retries` via `args = ["--retries=x"]` or add `{"@primer/deploy":{"retries":x}}` to your `package.json`. Fixes #6. 🤞 

### :house: Internal
* We now use `ecmaVersion: 2018` in our ESlint config so that we can use native async/await in our tests.