### PR TITLE
Prune failed deployments periodically

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,4 +1,4 @@
-workflow "lint, test, deploy" {
+workflow "lint, test, deploy, publish" {
   on = "push"
   resolves = [
     "lint",
@@ -10,23 +10,23 @@ workflow "lint, test, deploy" {
 
 action "npm install" {
   uses = "actions/npm@master"
-  runs = ["npm", "ci"]
+  runs = "npm ci"
 }
 
 action "lint" {
-  needs = ["npm install"]
+  needs = "npm install"
   uses = "actions/npm@master"
-  runs = ["npm", "run", "lint"]
+  runs = "npm run lint"
 }
 
 action "test" {
-  needs = ["npm install"]
+  needs = "npm install"
   uses = "actions/npm@master"
-  runs = ["npm", "test"]
+  runs = "npm test"
 }
 
 action "deploy" {
-  needs = ["test"]
+  needs = "test"
   uses = "./"
   secrets = [
     "GITHUB_TOKEN",

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -49,7 +49,8 @@ action "publish" {
 }
 
 action "prune" {
-  needs = "install"
+  needs = "npm install"
+  uses = "actions/npm@master"
   runs = "script/prune"
   secrets = [
     "GITHUB_TOKEN",

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -8,6 +8,11 @@ workflow "lint, test, deploy, publish" {
   ]
 }
 
+workflow "periodically prune old deployments" {
+  on = "schedule(*/15 * * * *)"
+  resolves = "prune"
+}
+
 action "npm install" {
   uses = "actions/npm@master"
   runs = "npm ci"
@@ -35,10 +40,19 @@ action "deploy" {
 }
 
 action "publish" {
-  needs = ["test"]
+  needs = "test"
   uses = "primer/publish@v1.0.0"
   secrets = [
     "GITHUB_TOKEN",
     "NPM_AUTH_TOKEN",
+  ]
+}
+
+action "prune" {
+  needs = "install"
+  runs = "script/prune"
+  secrets = [
+    "GITHUB_TOKEN",
+    "NOW_TOKEN",
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -160,46 +160,90 @@
       }
     },
     "@octokit/endpoint": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.1.2.tgz",
-      "integrity": "sha512-iRx4kDYybAv9tOrHDBE6HwlgiFi8qmbZl8SHliZWtxbUFuXLZXh2yv8DxGIK9wzD9J0wLDMZneO8vNYJNUSJ9Q==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.1.2.tgz",
+      "integrity": "sha512-bBGGmcRFq1x0jrB29G/9KjYmO3cdHfk3476B2JOHRvLsNw1Pn3l+ZvbiqtcO9qAS4Ti+zFedLB84ziHZRZclQA==",
       "requires": {
-        "deepmerge": "3.1.0",
-        "is-plain-object": "^2.0.4",
-        "universal-user-agent": "^2.0.1",
+        "deepmerge": "3.2.0",
+        "is-plain-object": "^3.0.0",
+        "universal-user-agent": "^2.1.0",
         "url-template": "^2.0.8"
-      }
-    },
-    "@octokit/request": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.3.0.tgz",
-      "integrity": "sha512-5YRqYNZOAaL7+nt7w3Scp6Sz4P2g7wKFP9npx1xdExMomk8/M/ICXVLYVam2wzxeY0cIc6wcKpjC5KI4jiNbGw==",
-      "requires": {
-        "@octokit/endpoint": "^3.1.1",
-        "is-plain-object": "^2.0.4",
-        "node-fetch": "^2.3.0",
-        "universal-user-agent": "^2.0.1"
       },
       "dependencies": {
-        "node-fetch": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-          "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
         }
       }
     },
-    "@octokit/rest": {
-      "version": "16.15.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.15.0.tgz",
-      "integrity": "sha512-Un+e7rgh38RtPOTe453pT/KPM/p2KZICimBmuZCd2wEo8PacDa4h6RqTPZs+f2DPazTTqdM7QU4LKlUjgiBwWw==",
+    "@octokit/request": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-4.1.0.tgz",
+      "integrity": "sha512-RvpQAba4i+BNH0z8i0gPRc1ShlHidj4puQjI/Tno6s+Q3/Mzb0XRSHJiOhpeFrZ22V7Mwjq1E7QS27P5CgpWYA==",
       "requires": {
-        "@octokit/request": "2.3.0",
-        "before-after-hook": "^1.2.0",
+        "@octokit/endpoint": "^5.1.0",
+        "@octokit/request-error": "^1.0.1",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^3.0.0",
+        "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^2.1.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+        },
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        }
+      }
+    },
+    "@octokit/request-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.0.2.tgz",
+      "integrity": "sha512-T9swMS/Vc4QlfWrvyeSyp/GjhXtYaBzCcibjGywV4k4D2qVrQKfEMPy8OxMDEj7zkIIdpHwqdpVbKCvnUPqkXw==",
+      "requires": {
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "16.26.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.26.0.tgz",
+      "integrity": "sha512-NBpzre44ZAQWZhlH+zUYTgqI0pHN+c9rNj4d+pCydGEiKTGc1HKmoTghEUyr9GxazDyoAvmpx9nL0I7QS1Olvg==",
+      "requires": {
+        "@octokit/request": "^4.0.1",
+        "@octokit/request-error": "^1.0.2",
+        "atob-lite": "^2.0.0",
+        "before-after-hook": "^1.4.0",
         "btoa-lite": "^1.0.0",
+        "deprecation": "^2.0.0",
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2",
         "lodash.uniq": "^4.5.0",
         "octokit-pagination-methods": "^1.1.0",
+        "once": "^1.4.0",
         "universal-user-agent": "^2.0.0",
         "url-template": "^2.0.8"
       }
@@ -434,6 +478,11 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "atob-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -589,9 +638,9 @@
       }
     },
     "before-after-hook": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.3.2.tgz",
-      "integrity": "sha512-zyPgY5dgbf99c0uGUjhY4w+mxqEGxPKg9RQDl34VvrVh2bM31lFN+mwR1ZHepq/KA3VCPk1gwJZL6IIJqjLy2w=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
+      "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -994,6 +1043,12 @@
         }
       }
     },
+    "dateformat": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+      "dev": true
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -1021,9 +1076,9 @@
       "dev": true
     },
     "deepmerge": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.1.0.tgz",
-      "integrity": "sha512-/TnecbwXEdycfbsM2++O3eGiatEFHjjNciHEwJclM+T5Kd94qD1AP+2elP/Mq0L5b9VZJao5znR01Mz6eX8Seg=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
+      "integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow=="
     },
     "default-require-extensions": {
       "version": "2.0.0",
@@ -1089,6 +1144,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "deprecation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.0.0.tgz",
+      "integrity": "sha512-lbQN037mB3VfA2JFuguM5GCJ+zPinMeCrFe+AfSZ6eqrnJA/Fs+EYMnd6Nb2mn9lf2jO9xwEd9o9lic+D4vkcw=="
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -2110,7 +2170,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2131,12 +2192,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2151,17 +2214,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2278,7 +2344,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2290,6 +2357,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2304,6 +2372,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2311,12 +2380,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2335,6 +2406,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2415,7 +2487,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2427,6 +2500,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2512,7 +2586,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2548,6 +2623,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2567,6 +2643,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2610,12 +2687,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3116,6 +3195,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -3175,7 +3255,26 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
+    "isomorphic-unfetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.0.0.tgz",
+      "integrity": "sha512-V0tmJSYfkKokZ5mgl0cmfQMTb7MLHsBMngTkbLY0eXvKqiVRRoZP04Ly+KhKrJfKtzC9E6Pp15Jo+bwh7Vi2XQ==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^2.2.0",
+        "unfetch": "^4.0.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+          "dev": true
+        }
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -3937,9 +4036,9 @@
       }
     },
     "macos-release": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.0.0.tgz",
-      "integrity": "sha512-iCM3ZGeqIzlrH7KxYK+fphlJpCCczyHXc+HhRVbEu9uNTCrzYJjvvtefzeKTCVHd5AP/aD/fzC80JZ4ZP+dQ/A=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.2.0.tgz",
+      "integrity": "sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA=="
     },
     "make-dir": {
       "version": "1.3.0",
@@ -4402,11 +4501,11 @@
       }
     },
     "os-name": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.0.0.tgz",
-      "integrity": "sha512-7c74tib2FsdFbQ3W+qj8Tyd1R3Z6tuVRNNxXjJcZ4NgjIEQU9N/prVMqcW29XZPXGACqaXN3jq58/6hoaoXH6g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
+      "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
       "requires": {
-        "macos-release": "^2.0.0",
+        "macos-release": "^2.2.0",
         "windows-release": "^3.1.0"
       }
     },
@@ -5644,6 +5743,12 @@
         }
       }
     },
+    "unfetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.1.0.tgz",
+      "integrity": "sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg==",
+      "dev": true
+    },
     "union-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
@@ -5680,9 +5785,9 @@
       }
     },
     "universal-user-agent": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.3.tgz",
-      "integrity": "sha512-eRHEHhChCBHrZsA4WEhdgiOKgdvgrMIHwnwnqD0r5C6AO8kwKcG7qSku3iXdhvHL3YvsS9ZkSGN8h/hIpoFC8g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.1.0.tgz",
+      "integrity": "sha512-8itiX7G05Tu3mGDTdNY2fB4KJ8MgZLS54RdG6PkkfwMAavrXu1mV/lls/GABx9O3Rw4PnTtasxrvbMQoBYY92Q==",
       "requires": {
         "os-name": "^3.0.0"
       }
@@ -5884,32 +5989,11 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "windows-release": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.1.0.tgz",
-      "integrity": "sha512-hBb7m7acFgQPQc222uEQTmdcGLeBmQLNLFIh0rDk3CwFOBrfjefLzEfEfmpMq8Af/n/GnFf3eYf203FY1PmudA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
+      "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
       "requires": {
-        "execa": "^0.10.0"
-      },
-      "dependencies": {
-        "execa": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-        }
+        "execa": "^1.0.0"
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "version": "script/version",
-    "lint": "eslint *.js src",
+    "lint": "eslint *.js src script/prune",
     "test": "jest"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,11 @@
     "yargs": "^12.0.5"
   },
   "devDependencies": {
+    "@octokit/rest": "^16.26.0",
+    "dateformat": "^3.0.3",
     "eslint": "^5.12.1",
     "eslint-plugin-github": "^1.8.1",
+    "isomorphic-unfetch": "^3.0.0",
     "jest": "^24.0.0",
     "mocked-env": "^1.2.4"
   }

--- a/script/prune
+++ b/script/prune
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+const dateFormat = require('dateformat')
+const Octokit = require('@octokit/rest')
+const Now = require('../src/now-api')
+
+const NOW_TOKEN = requireEnv('NOW_TOKEN')
+const GITHUB_TOKEN = requireEnv('GITHUB_TOKEN')
+
+const FAILED_STATES = new Set(['BUILD_ERROR', 'ERROR', 'FROZEN'])
+
+const REPO_URL_PREFIXES = {
+  'primer-g-octicon-': {owner: 'primer', repo: 'g-octicon'}
+}
+
+const github = new Octokit({auth: `token ${GITHUB_TOKEN}`})
+const now = new Now({token: NOW_TOKEN})
+
+console.warn(`Fetching deployments...`)
+// Get all of the deployments
+now.deployments.list().then(async deployments => {
+  console.warn(`Found ${deployments.length} deployments`)
+  // Split them into two lists: the ones that failed, and the ones that didn't
+  const [failed, remaining] = split(deployments, d => FAILED_STATES.has(d.state))
+  console.warn(`Found ${failed.length} failed deployments to remove`)
+
+  // sort by creation timestamp ascending (earliest first)
+  failed.sort((a, b) => a.created - b.created)
+
+  // Remove the failed ones
+  for (const deployment of failed) {
+    console.warn(`𐄂 removing ${deployment.url} (state: "${deployment.state}", created ${date(deployment.created)})`)
+    await now.deployments.remove({id: deployment.uid})
+      .catch(error => console.warn(`  ! Failed to remove ${deployment.uid}:`, error))
+  }
+
+  // Make a mapping of deployments by UID
+  const deploymentsById = new Map()
+  const deploymentsByUrl = new Map()
+  for (const deployment of remaining) {
+    deploymentsById.set(deployment.uid, deployment)
+    deploymentsByUrl.set(deployment.url, deployment)
+    deployment.aliases = []
+  }
+
+  console.warn(`Fetching aliases...`)
+  // Get all of the aliases
+  return now.aliases.list().then(aliases => {
+    console.warn(`Found ${aliases.length} aliases`)
+    // Associate the aliases with their respective deployments
+    for (const alias of aliases) {
+      let deployment
+      if (alias.deployment) {
+        // Aliases with a "deployment" key can be looked up by deployment UID
+        deployment = deploymentsById.get(alias.deployment.id)
+      // 
+      } else if (alias.rules) {
+        // Aliases with "rules" arrays will have a "root" URL in the last
+        // entry's "dest"
+        const destUrl = alias.rules[alias.rules.length - 1].dest
+        deployment = deploymentsByUrl.get(destUrl)
+      }
+      if (deployment) {
+        const aliasUrl = alias.alias
+        deployment.aliases.push(aliasUrl)
+        break
+      }
+    }
+    return remaining
+  })
+})
+.then(deployments => {
+  // next, filter out deployments that are aliased to 
+  const deploymentsByRepo = new Map()
+  for (const deployment of deployments) {
+    for (const alias of deployment.aliases) {
+      const context = getContextForUrl(alias)
+      if (context) {
+        const {owner, repo} = context
+        const slug = `${owner}/${repo}`
+        if (deploymentsByRepo.has(slug)) {
+          deploymentsByRepo.get(slug).push(deployment)
+        } else {
+          deploymentsByRepo.set(slug, [deployment])
+        }
+      }
+      break
+    }
+  }
+
+  for (const [slug, deployments] of deploymentsByRepo.entries()) {
+    console.warn(`${slug}: ${deployments.length} deployments:`)
+    for (const {url, created, aliases} of deployments) {
+      console.warn('\t', date(created), url, `aliases: ${aliases.join(', ')}`)
+    }
+  }
+})
+
+function getContextForUrl(url) {
+  for (const prefix of Object.keys(REPO_URL_PREFIXES)) {
+    if (url.startsWith(prefix)) {
+      const {owner, repo} = REPO_URL_PREFIXES[prefix]
+      const suffix = url.substr(prefix.length).replace('.now.sh', '')
+      return {owner, repo, suffix}
+    }
+  }
+  const match = url.match(/^primer-(\w+)-(.+)\.now\.sh$/)
+  if (match) {
+    return {
+      owner: 'primer',
+      repo: match[1],
+      suffix: match[2]
+    }
+  }
+}
+
+function requireEnv(name, ...message) {
+  const value = process.env[name]
+  if (value) {
+    return value
+  } else {
+    die(`process.env.${name} is not set. Please add "${name}" to this action's secrets.`, ...message)
+  }
+}
+
+function die(...message) {
+  console.error(...message)
+  process.exitCode = 1
+}
+
+function date(timestamp, format = 'yyyy/mm/dd HH:MM:ss') {
+  return dateFormat(timestamp, format)
+}
+
+function split(list, test) {
+  const yes = []
+  const no = []
+  for (const item of list) {
+    (test(item) ? yes : no).push(item)
+  }
+  return [yes, no]
+}

--- a/script/prune
+++ b/script/prune
@@ -6,7 +6,7 @@ const Now = require('../src/now-api')
 const NOW_TOKEN = requireEnv('NOW_TOKEN')
 // const GITHUB_TOKEN = requireEnv('GITHUB_TOKEN')
 
-const FAILED_STATES = new Set(['BUILD_ERROR', 'ERROR', 'FROZEN'])
+const FAILED_STATES = new Set(['BUILD_ERROR', 'ERROR' /*, 'FROZEN' */])
 
 const REPO_URL_PREFIXES = {
   'primer-g-octicon-': {owner: 'primer', repo: 'g-octicon'}

--- a/script/prune
+++ b/script/prune
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 const dateFormat = require('dateformat')
-const Octokit = require('@octokit/rest')
+// const Octokit = require('@octokit/rest')
 const Now = require('../src/now-api')
 
 const NOW_TOKEN = requireEnv('NOW_TOKEN')
-const GITHUB_TOKEN = requireEnv('GITHUB_TOKEN')
+// const GITHUB_TOKEN = requireEnv('GITHUB_TOKEN')
 
 const FAILED_STATES = new Set(['BUILD_ERROR', 'ERROR', 'FROZEN'])
 
@@ -12,88 +12,91 @@ const REPO_URL_PREFIXES = {
   'primer-g-octicon-': {owner: 'primer', repo: 'g-octicon'}
 }
 
-const github = new Octokit({auth: `token ${GITHUB_TOKEN}`})
+// const github = new Octokit({auth: `token ${GITHUB_TOKEN}`})
 const now = new Now({token: NOW_TOKEN})
 
 console.warn(`Fetching deployments...`)
 // Get all of the deployments
-now.deployments.list().then(async deployments => {
-  console.warn(`Found ${deployments.length} deployments`)
-  // Split them into two lists: the ones that failed, and the ones that didn't
-  const [failed, remaining] = split(deployments, d => FAILED_STATES.has(d.state))
-  console.warn(`Found ${failed.length} failed deployments to remove`)
+now.deployments
+  .list()
+  .then(async deployments => {
+    console.warn(`Found ${deployments.length} deployments`)
+    // Split them into two lists: the ones that failed, and the ones that didn't
+    const [failed, remaining] = split(deployments, d => FAILED_STATES.has(d.state))
+    console.warn(`Found ${failed.length} failed deployments to remove`)
 
-  // sort by creation timestamp ascending (earliest first)
-  failed.sort((a, b) => a.created - b.created)
+    // sort by creation timestamp ascending (earliest first)
+    failed.sort((a, b) => a.created - b.created)
 
-  // Remove the failed ones
-  for (const deployment of failed) {
-    console.warn(`𐄂 removing ${deployment.url} (state: "${deployment.state}", created ${date(deployment.created)})`)
-    await now.deployments.remove({id: deployment.uid})
-      .catch(error => console.warn(`  ! Failed to remove ${deployment.uid}:`, error))
-  }
+    // Remove the failed ones
+    for (const deployment of failed) {
+      console.warn(`𐄂 removing ${deployment.url} (state: "${deployment.state}", created ${date(deployment.created)})`)
+      await now.deployments
+        .remove({id: deployment.uid})
+        .catch(error => console.warn(`  ! Failed to remove ${deployment.uid}:`, error))
+    }
 
-  // Make a mapping of deployments by UID
-  const deploymentsById = new Map()
-  const deploymentsByUrl = new Map()
-  for (const deployment of remaining) {
-    deploymentsById.set(deployment.uid, deployment)
-    deploymentsByUrl.set(deployment.url, deployment)
-    deployment.aliases = []
-  }
+    // Make a mapping of deployments by UID
+    const deploymentsById = new Map()
+    const deploymentsByUrl = new Map()
+    for (const deployment of remaining) {
+      deploymentsById.set(deployment.uid, deployment)
+      deploymentsByUrl.set(deployment.url, deployment)
+      deployment.aliases = []
+    }
 
-  console.warn(`Fetching aliases...`)
-  // Get all of the aliases
-  return now.aliases.list().then(aliases => {
-    console.warn(`Found ${aliases.length} aliases`)
-    // Associate the aliases with their respective deployments
-    for (const alias of aliases) {
-      let deployment
-      if (alias.deployment) {
-        // Aliases with a "deployment" key can be looked up by deployment UID
-        deployment = deploymentsById.get(alias.deployment.id)
-      // 
-      } else if (alias.rules) {
-        // Aliases with "rules" arrays will have a "root" URL in the last
-        // entry's "dest"
-        const destUrl = alias.rules[alias.rules.length - 1].dest
-        deployment = deploymentsByUrl.get(destUrl)
+    console.warn(`Fetching aliases...`)
+    // Get all of the aliases
+    return now.aliases.list().then(aliases => {
+      console.warn(`Found ${aliases.length} aliases`)
+      // Associate the aliases with their respective deployments
+      for (const alias of aliases) {
+        let deployment
+        if (alias.deployment) {
+          // Aliases with a "deployment" key can be looked up by deployment UID
+          deployment = deploymentsById.get(alias.deployment.id)
+          //
+        } else if (alias.rules) {
+          // Aliases with "rules" arrays will have a "root" URL in the last
+          // entry's "dest"
+          const destUrl = alias.rules[alias.rules.length - 1].dest
+          deployment = deploymentsByUrl.get(destUrl)
+        }
+        if (deployment) {
+          const aliasUrl = alias.alias
+          deployment.aliases.push(aliasUrl)
+          break
+        }
       }
-      if (deployment) {
-        const aliasUrl = alias.alias
-        deployment.aliases.push(aliasUrl)
+      return remaining
+    })
+  })
+  .then(deployments => {
+    // next, filter out deployments that are aliased to
+    const deploymentsByRepo = new Map()
+    for (const deployment of deployments) {
+      for (const alias of deployment.aliases) {
+        const context = getContextForUrl(alias)
+        if (context) {
+          const {owner, repo} = context
+          const slug = `${owner}/${repo}`
+          if (deploymentsByRepo.has(slug)) {
+            deploymentsByRepo.get(slug).push(deployment)
+          } else {
+            deploymentsByRepo.set(slug, [deployment])
+          }
+        }
         break
       }
     }
-    return remaining
-  })
-})
-.then(deployments => {
-  // next, filter out deployments that are aliased to 
-  const deploymentsByRepo = new Map()
-  for (const deployment of deployments) {
-    for (const alias of deployment.aliases) {
-      const context = getContextForUrl(alias)
-      if (context) {
-        const {owner, repo} = context
-        const slug = `${owner}/${repo}`
-        if (deploymentsByRepo.has(slug)) {
-          deploymentsByRepo.get(slug).push(deployment)
-        } else {
-          deploymentsByRepo.set(slug, [deployment])
-        }
-      }
-      break
-    }
-  }
 
-  for (const [slug, deployments] of deploymentsByRepo.entries()) {
-    console.warn(`${slug}: ${deployments.length} deployments:`)
-    for (const {url, created, aliases} of deployments) {
-      console.warn('\t', date(created), url, `aliases: ${aliases.join(', ')}`)
+    for (const [slug, deployments] of deploymentsByRepo.entries()) {
+      console.warn(`${slug}: ${deployments.length} deployments:`)
+      for (const {url, created, aliases} of deployments) {
+        console.warn('\t', date(created), url, `aliases: ${aliases.join(', ')}`)
+      }
     }
-  }
-})
+  })
 
 function getContextForUrl(url) {
   for (const prefix of Object.keys(REPO_URL_PREFIXES)) {
@@ -135,7 +138,7 @@ function split(list, test) {
   const yes = []
   const no = []
   for (const item of list) {
-    (test(item) ? yes : no).push(item)
+    ;(test(item) ? yes : no).push(item)
   }
   return [yes, no]
 }

--- a/src/now-api.js
+++ b/src/now-api.js
@@ -1,0 +1,77 @@
+const fetch = require('isomorphic-unfetch')
+const {join} = require('path')
+
+module.exports = class Now {
+  constructor(options) {
+    const {
+      version = 2,
+      baseUrl = `https://api.zeit.co/v${version}/now`,
+      headers = {},
+      token
+    } = options
+    this.options = options
+    this.baseUrl = baseUrl
+    this.headers = headers
+    if (token) {
+      this.headers.Authorization = `Bearer ${token}`
+    }
+  }
+
+  get deployments() {
+    return {
+      list: args => this.listDeployments(args),
+      get: args => this.getDeployment(args),
+      remove: args => this.removeDeployment(args)
+    }
+  }
+
+  get aliases() {
+    return {
+      list: args => this.listAliases(args),
+      get: args => this.getAlias(args),
+      remove: args => this.removeAlias(args)
+    }
+  }
+
+  fetch(uri, options = {}) {
+    const url = `${this.baseUrl}/${uri}`
+    options.headers = Object.assign({}, this.headers, options.headers)
+    return fetch(url, options).then(res => res.json())
+  }
+
+  listDeployments(args) {
+    return this.fetch('deployments').then(data => data.deployments)
+  }
+
+  getDeployment(args) {
+    const [id] = requireArgs(args, 'id')
+    return this.fetch(`deployments/${id}`)
+  }
+
+  removeDeployment(args) {
+    const [id] = requireArgs(args, 'id')
+    return this.fetch(`deployments/${id}`, {method: 'DELETE'})
+  }
+
+  listAliases(args) {
+    return this.fetch('aliases').then(data => data.aliases)
+  }
+}
+
+function requireArgs(args, ...keys) {
+  const values = []
+  const missing = []
+  for (const key of keys) {
+    if (!args[key]) {
+      missing.push(key)
+    } else {
+      values.push(args[key])
+    }
+  }
+  if (missing.length > 1) {
+    throw new Error(`Required arguments "${missing.join('", "')}" are missing in: ${JSON.stringify(args)}`)
+  } else if (missing.length === 1) {
+    throw new Error(`Required argument "${missing[0]}" is missing in: ${JSON.stringify(args)}`)
+  }
+  return values
+}

--- a/src/now-api.js
+++ b/src/now-api.js
@@ -1,14 +1,8 @@
 const fetch = require('isomorphic-unfetch')
-const {join} = require('path')
 
 module.exports = class Now {
   constructor(options) {
-    const {
-      version = 2,
-      baseUrl = `https://api.zeit.co/v${version}/now`,
-      headers = {},
-      token
-    } = options
+    const {version = 2, baseUrl = `https://api.zeit.co/v${version}/now`, headers = {}, token} = options
     this.options = options
     this.baseUrl = baseUrl
     this.headers = headers
@@ -19,17 +13,17 @@ module.exports = class Now {
 
   get deployments() {
     return {
-      list: args => this.listDeployments(args),
-      get: args => this.getDeployment(args),
-      remove: args => this.removeDeployment(args)
+      list: (...args) => this.listDeployments(...args),
+      get: (...args) => this.getDeployment(...args),
+      remove: (...args) => this.removeDeployment(...args)
     }
   }
 
   get aliases() {
     return {
-      list: args => this.listAliases(args),
-      get: args => this.getAlias(args),
-      remove: args => this.removeAlias(args)
+      list: (...args) => this.listAliases(...args),
+      get: (...args) => this.getAlias(...args),
+      remove: (...args) => this.removeAlias(...args)
     }
   }
 
@@ -39,7 +33,7 @@ module.exports = class Now {
     return fetch(url, options).then(res => res.json())
   }
 
-  listDeployments(args) {
+  listDeployments() {
     return this.fetch('deployments').then(data => data.deployments)
   }
 
@@ -53,7 +47,7 @@ module.exports = class Now {
     return this.fetch(`deployments/${id}`, {method: 'DELETE'})
   }
 
-  listAliases(args) {
+  listAliases() {
     return this.fetch('aliases').then(data => data.aliases)
   }
 }


### PR DESCRIPTION
This uses the [Zeit API](https://zeit.co/docs/api) to list all of the deployments (using a `NOW_TOKEN` secret generated in the Primer team, so really only deployments in the Primer org) and, one by one, [delete](https://zeit.co/docs/api#endpoints/deployments/delete-a-deployment) the ones with obviously failed (`ERROR`, `BUILD_ERROR`) states. I've tested this by running it locally:

```sh
# copy your Now access token
export NOW_TOKEN=$(pbpaste)
script/prune
```

and it produces output that looks like this:

```
Fetching deployments...
Found 2203 deployments
Found 247 failed deployments to remove
𐄂 removing primer-style-gwoadaqojf.now.sh (state: "BUILD_ERROR", created 2018/10/12 15:59:26)
𐄂 removing primer-style-jtzzkksfpt.now.sh (state: "BUILD_ERROR", created 2018/10/14 22:27:20)
𐄂 removing primer-style-qrebppjdvu.now.sh (state: "BUILD_ERROR", created 2018/10/14 22:30:12)
𐄂 removing primer-style-mqrpdaojnq.now.sh (state: "BUILD_ERROR", created 2018/10/14 22:45:14)
𐄂 removing primer-style-gcybreifin.now.sh (state: "BUILD_ERROR", created 2018/10/15 08:24:51)
𐄂 removing primer-components-adjknizvym.now.sh (state: "BUILD_ERROR", created 2018/10/29 09:04:32)
```

~I'm not 100% clear on whether we have to merge the Actions workflow changes to the default branch before the [scheduled](https://developer.github.com/actions/managing-workflows/creating-and-cancelling-a-workflow/#scheduling-a-workflow) one will run every 15 minutes, but I'd like to keep this open for 15 minutes to see if it happens without merging.~ I found the relevant bit in the docs:

>  A scheduled workflow will use the workflow file checked into the default branch (usually `master`).

So I guess we merge this and then we can see what happens? 😬 